### PR TITLE
Remove Beach Mode from title

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <link rel="icon" type="image/x-icon" href="blue.ico" />
-  <title>HTML Day 2026: Montréal (Beach Mode)</title>
+  <title>HTML Day 2026: Montréal</title>
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="HTML Day 2026: Montreal (Beach Mode)" />
+  <meta name="twitter:title" content="HTML Day 2026: Montreal" />
   <meta name="twitter:description" content="Saturday, August 8, 2026, 15h to 18h, Verdun beach" />
   <meta name="twitter:image" content="https://html.blue/blue.png" />
   <style>


### PR DESCRIPTION
## Summary
- remove Beach Mode wording from the page and social titles

## Validation
- reviewed the two-line title diff

Closes #10