### PR TITLE
Change event time separator

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <title>HTML Day 2026: Montréal</title>
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="HTML Day 2026: Montreal" />
-  <meta name="twitter:description" content="Saturday, August 8, 2026, 15h to 18h, Verdun beach" />
+  <meta name="twitter:description" content="Saturday, August 8, 2026, 15h à 18h, Verdun beach" />
   <meta name="twitter:image" content="https://html.blue/blue.png" />
   <style>
     body {
@@ -46,7 +46,7 @@
   <br>
   <h2>
     Samedi, le <time datetime="2026-08-08">8 août</time> 2026<br>
-    15h to 18h<br />
+    15h à 18h<br />
     Plage de Verdun≈Verdun beach
   </h2>
   <br>


### PR DESCRIPTION
## Summary
- change '15h to 18h' to '15h à 18h' in metadata and visible copy

## Validation
- reviewed the two-line time diff

Closes #22